### PR TITLE
Match scale with the image/labels

### DIFF
--- a/src/napari_trackastra/_tests/test_demo_widget.py
+++ b/src/napari_trackastra/_tests/test_demo_widget.py
@@ -7,14 +7,16 @@ from napari_trackastra._widget import Tracker
 def test_demo_widget():
     viewer = napari.Viewer()
     img, mask = example_data_bacteria()
-    viewer.add_image(img)
-    viewer.add_labels(mask)
+    scale = (1,1.2,1.2)
+    viewer.add_image(img, scale=scale)
+    viewer.add_labels(mask, scale=scale)
 
     # Test widget only on CPU
     tracker = Tracker(viewer, device="cpu")
     viewer.window.add_dock_widget(tracker)
     tracker._run()
     tracker._save()
+    napari.run()
 
 
 if __name__ == "__main__":

--- a/src/napari_trackastra/_widget.py
+++ b/src/napari_trackastra/_widget.py
@@ -171,20 +171,23 @@ class Tracker(Container):
         )
         if len(lays) > 0:
             lays[0].data = masks_tracked
+            lays[0].scale = self._mask_layer.value.scale
         else:
-            self._viewer.add_labels(masks_tracked, name="masks_tracked")
+            self._viewer.add_labels(masks_tracked, name="masks_tracked",scale=self._mask_layer.value.scale)
 
         lays = tuple(
             lay for lay in self._viewer.layers if lay.name == "tracks"
         )
         if len(lays) > 0:
             lays[0].data = napari_tracks
+            lays[0].scale = self._image_layer.value.scale
         else:
             self._viewer.add_tracks(
                 napari_tracks,
                 graph=napari_tracks_graph,
                 name="tracks",
                 tail_length=5,
+                scale=self._image_layer.value.scale
             )
 
         self._save_path.show()

--- a/src/napari_trackastra/_widget.py
+++ b/src/napari_trackastra/_widget.py
@@ -156,6 +156,9 @@ class Tracker(Container):
         imgs = np.asarray(self._image_layer.value.data)
         masks = np.asarray(self._mask_layer.value.data)
 
+        imgs_scale = self._image_layer.value.scale
+        masks_scale = self._mask_layer.value.scale
+        
         self._show_activity_dock(True)
         track_graph, masks_tracked, napari_tracks, napari_tracks_graph = (
             _track_function(
@@ -171,7 +174,7 @@ class Tracker(Container):
         )
         if len(lays) > 0:
             lays[0].data = masks_tracked
-            lays[0].scale = self._mask_layer.value.scale
+            lays[0].scale = masks_scale
         else:
             self._viewer.add_labels(masks_tracked, name="masks_tracked",scale=self._mask_layer.value.scale)
 
@@ -180,14 +183,14 @@ class Tracker(Container):
         )
         if len(lays) > 0:
             lays[0].data = napari_tracks
-            lays[0].scale = self._image_layer.value.scale
+            lays[0].scale = imgs_scale
         else:
             self._viewer.add_tracks(
                 napari_tracks,
                 graph=napari_tracks_graph,
                 name="tracks",
                 tail_length=5,
-                scale=self._image_layer.value.scale
+                scale=imgs_scale,
             )
 
         self._save_path.show()


### PR DESCRIPTION
If the image masks contain  pixel size, napari modifies the scale factor upon loading. Your plugin doesn't take into account this scale factor, this PR fixes that (entirely, I hope)