### PR TITLE
Update icon manifest syntax for upcoming npe2 change

### DIFF
--- a/src/napari_trackastra/napari.yaml
+++ b/src/napari_trackastra/napari.yaml
@@ -3,7 +3,7 @@ display_name: trackastra
 # use 'hidden' to remove plugin from napari hub search results
 visibility: public
 categories: ["Image Processing"]
-icon: resources/icon.png
+icon: napari_trackastra.resources:icon.png
 contributions:
   commands:
     - id: napari-trackastra.example_data_bacteria


### PR DESCRIPTION
## Summary

Addresses #9. napari is changing how plugins declare icons in their manifests (napari/npe2#450, napari/napari#8682). The current plain file-path form `icon: resources/icon.png` will no longer be supported — icons must be declared as a package resource reference of the form `package.module:filename`.

This PR updates the `icon` field in `src/napari_trackastra/napari.yaml`:

```diff
-icon: resources/icon.png
+icon: napari_trackastra.resources:icon.png
```

This points to the same `src/napari_trackastra/resources/icon.png`, which is already shipped with the package via `MANIFEST.in` (`include-package-data = true`), so no packaging changes are needed.

## Testing

- Manifest still parses as valid YAML and the `icon` field resolves to the recommended `napari_trackastra.resources:icon.png`.
- No other references to the old `resources/icon.png` path exist in the codebase.

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)